### PR TITLE
Switch to Java 17

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+24
+* Change default Java version to 17
+
 19
 * Moving Changelog to plain text file at project root.
 * Switching to release-plugin 2.5 to support git 1.8.

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
       <plugin>
         <groupId>de.thetaphi</groupId>
         <artifactId>forbiddenapis</artifactId>
-        <version>2.7</version>
+        <version>3.3</version> <!-- v3.3 needed for Java 17 definitions -->
         <configuration>
           <!--
               if the used Java version is too new,
@@ -183,8 +183,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <!-- Can be overridden in project pom.xml -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <api.check.phase>none</api.check.phase>
     <test.excludedGroups>slow</test.excludedGroups>
   </properties>


### PR DESCRIPTION
Switches to Java 17 as default language level and bumps ForbiddenAPIs accordingly.

New projects should use Java 17 unless there is some reason not to. It can always be overridden in the project `pom.xml` with   
```
<properties>
    <maven.compiler.source>17</maven.compiler.source>
    <maven.compiler.target>17</maven.compiler.target>
  </properties>
```

Consider:

Existing projects that do not have the language level specified and bumps the parent `pom.xml` dependency will switch to Java 17, if the version is not explicitly set in the project's `pom.xml`. This might be dangerous as KB is it might not be noticed and can lead to confusion. On the other hand, all projects ought to set the Java version in the project `pom.xml` exactly to avoid such scenarios.

An alternative would be to keep the default version at 11 in sbforge-parent and just bump the ForbiddenAPIs (the 3.3 also works under Java 11): Less confusion but also less push to let new projects use Java 17.