### PR TITLE
Added unittest annotation tags blocked and integrationTest

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+unreleased:
+* Added two new unittest annotations 'blocked' and 'integrationTest'. All test annotation with these will not be run automatic
+
 24
 * Change default Java version to 17
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 unreleased:
-* Added two new unittest annotations 'blocked' and 'integrationTest'. All test annotation with these will not be run automatic
+* Added two new unittest annotations 'blocked' and 'integration'. All test annotation with these will not be run automatic
 
 24
 * Change default Java version to 17

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,6 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <api.check.phase>none</api.check.phase>
-    <test.excludedGroups>slow</test.excludedGroups>
+    <test.excludedGroups>slow,blocked,integrationTest</test.excludedGroups>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,6 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <api.check.phase>none</api.check.phase>
-    <test.excludedGroups>slow,blocked,integrationTest</test.excludedGroups>
+    <test.excludedGroups>slow,blocked,integration</test.excludedGroups>
   </properties>
 </project>


### PR DESCRIPTION
Added two new annotation that can be used for unittests to excludes list. Unittest with these annotation will not be run automatic.

To run all unittest with integrationTest use:
mvn test -DincludedGroups=integrationTest

It can also be added permanent to your local maven setting.
